### PR TITLE
adds annotatorjs api endpoint /destroy for mirador2

### DIFF
--- a/anno/tests/test_urls.py
+++ b/anno/tests/test_urls.py
@@ -30,6 +30,9 @@ def test_urls():
             'url': reverse('compat_delete', kwargs={'anno_id': '123456789'}),
             'view_func': 'anno.views.crud_compat_delete'},
         {
+            'url': reverse('compat_destroy', kwargs={'anno_id': '123456789'}),
+            'view_func': 'anno.views.crud_compat_delete'},
+        {
             'url': reverse('compat_read', kwargs={'anno_id': '123456789'}),
             'view_func': 'anno.views.crud_compat_read'},
         {

--- a/anno/urls.py
+++ b/anno/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
         views.crud_compat_update, name='compat_update'),
     re_path(r'^delete/(?P<anno_id>[0-9]+)$',
         views.crud_compat_delete, name='compat_delete'),
+    re_path(r'^destroy/(?P<anno_id>[0-9]+)$',
+        views.crud_compat_delete, name='compat_destroy'),
     re_path(r'^read/(?P<anno_id>[0-9]+)$',
         views.crud_compat_read, name='compat_read'),
 


### PR DESCRIPTION
- mirador2 uses /destroy instead of /delete; adding for compatibility!